### PR TITLE
Getting a user's email

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -216,6 +216,14 @@ Discourse.prototype.fetchConfirmationValue = function(callback) {
 
 };
 
+Discourse.prototype.getUserEmail = function(username, callback) {
+  this.put('users/' + username + '/emails.json',
+    {context: '/users/' + username + '/activity'},
+    function(error, body, httpCode) {
+      callback(error, body, httpCode);
+    }
+  );
+};
 
 
 ///////////////////////

--- a/test/user.js
+++ b/test/user.js
@@ -134,4 +134,24 @@ describe('Discourse User API', function() {
     });
   });
 
+  it('gets a user email', function(done) {
+
+    // username is assigned in previous test
+
+    api.getUserEmail(username, function(err, body, httpCode) {
+
+      // make assertions
+      should.not.exist(err);
+      should.exist(body);
+      httpCode.should.equal(200);
+
+      var json = JSON.parse(body);
+
+      // make more assertions
+      json.should.have.properties('email');
+
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This PR originated from the fact that I couldn't retrieve user emails when using `getUser` - the response would never hold the user's registration email.  Two notes:

* The API for fetching the user email is nowhere to be found.  Also had a look at https://github.com/discourse/discourse_api and it didn't have anything like that in there.  So I reverse engineered this by browsing as admin into a specific user's profile and clicking the "Show Email" button, and tracking the network tab in Chrome dev tools.  To my surprise this is a `PUT` request and not a `GET`.
* I didn't manage to get the tests running and couldn't spare the time to run everything on Docker \ Digital Ocean, but I'm almost 100% sure that it'll work because it's a simple test case.  Would appreciate if someone could help with that.