### PR TITLE
Avoid 'undefined' response error when connection cannot be established to discourse

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -55,7 +55,7 @@ Discourse.prototype.get = function(url, parameters, callback) {
         error = new Error(body.description || body.error_message);
       }
       else {
-        callback(error, body || {}, response.statusCode);
+        callback(error, body || {}, response != null ? response.statusCode : null);
       }
 
     }
@@ -77,7 +77,7 @@ Discourse.prototype.post = function(url, parameters, callback) {
       error = new Error(body.description || body.error_message);
     }
 
-    callback(error, body || {}, response.statusCode);
+    callback(error, body || {}, response != null ? response.statusCode : null);
 
   });
 
@@ -98,7 +98,7 @@ Discourse.prototype.put = function(url, parameters, callback) {
         error = new Error(body.description || body.error_message);
       }
 
-      callback(error, body || {}, response.statusCode);
+      callback(error, body || {}, response != null ? response.statusCode : null);
 
     });
 
@@ -119,7 +119,7 @@ Discourse.prototype.delete = function(url, parameters, callback) {
         error = new Error(body.description || body.error_message);
       }
 
-      callback(error, body || {}, response.statusCode);
+      callback(error, body || {}, response != null ? response.statusCode : null);
 
     });
 


### PR DESCRIPTION
Handle connection failures when discourse server is unavailable or url is incorrect.

Avoiding this error in main branch:

TypeError: Cannot read property 'statusCode' of undefined
    at Request._callback (/home/chris/discourse-integration/node_modules/discourse-api/lib/discourse.js:79:41)
    at self.callback (/home/chris/dev/discourse-integration/node_modules/discourse-api/node_modules/request/request.js:123:22)
    at Request.EventEmitter.emit (events.js:95:17)
    at ClientRequest.self.clientErrorHandler (/home/chris/dev/discourse-integration/node_modules/discourse-api/node_modules/request/request.js:232:10)
    at ClientRequest.EventEmitter.emit (events.js:95:17)
    at Socket.socketErrorListener (http.js:1547:9)
    at Socket.EventEmitter.emit (events.js:95:17)
    at net.js:441:14
    at process._tickCallback (node.js:415:13)