### PR TITLE
Additional methods for the API

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -162,6 +162,19 @@ Discourse.prototype.getUser = function(username, callback) {
   );
 };
 
+Discourse.prototype.getUserActivity = function(username, offset, callback) {
+  this.get('user_actions.json',
+    {
+      username: username,
+      filter: actionTypeEnum.REPLY,
+      offset: offset || 0
+    },
+    function(error, body, httpCode){
+      callback(error, body, httpCode);
+    }
+  );
+}
+
 Discourse.prototype.approveUser = function(id, username, callback) {
   this.put('admin/users/' + id + '/approve',
     { context: 'admin/users/' + username },
@@ -214,7 +227,34 @@ Discourse.prototype.fetchConfirmationValue = function(callback) {
 
 };
 
+///////////////////////
+// GROUPS
+///////////////////////
 
+Discourse.prototype.getGroupMembers = function(groupName, callback) {
+  this.get('groups/'+groupName+'/members.json', {}, function(error, body, httpCode) {
+    callback(error, body, httpCode);
+  });
+};
+
+Discourse.prototype.createGroup = function(groupName, aliasLevel, automatic, email_domains, membership_retroactive, trust_level, primary_group, title, visible, callback) {
+  this.post('admin/groups',
+    {
+      'name': groupName,
+      'alias_level': aliasLevel || -2,
+      'automatic': automatic || false,
+      'automatic_membership_email_domains': email_domains || "",
+      'automatic_membership_retroactive': membership_retroactive || false,
+      'grant_trust_level': trust_level || 1,
+      'primary_group': primary_group || false,
+      'title': title,
+      'visible': visible || true
+    },
+    function(error, body, httpCode) {
+      callback(error, body, httpCode);
+    }
+  );
+};
 
 ///////////////////////
 // TOPICS AND REPLIES
@@ -241,6 +281,12 @@ Discourse.prototype.getCreatedTopics = function(username, callback) {
   );
 
 };
+
+Discourse.prototype.getPost = function(post_id, callback) {
+  this.get('posts/'+post_id+'.json',{},function(error, body, httpCode){
+    callback(error, body, httpCode);
+  })
+}
 
 Discourse.prototype.replyToTopic = function(raw, topic_id, callback) {
   this.post('posts', { 'raw': raw, 'topic_id': topic_id }, function(error, body, httpCode) {


### PR DESCRIPTION
Not sure if you are looking to add this functionality but I found these useful for extracting a users post history from discourse for analysis. 

Added methods to 
 - get users replies with optional offset value
 - get contents of single post by post_id
 - get members of a group
 - create a group