### PR TITLE
Add method to get the last post id

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -306,6 +306,16 @@ Discourse.prototype.updatePost = function(post_id, raw, edit_reason, callback) {
 
 };
 
+Discourse.prototype.getLastPostId = function(callback) {
+
+  this.get('/posts.json',
+    {},
+    function (error, body, httpCode) {
+      callback(error, JSON.parse(body).latest_posts[0].id, httpCode);
+    }
+  );
+
+};
 
 
 /////////////////////
@@ -504,6 +514,13 @@ Discourse.prototype.createTopicSync = function(title, raw, category) {
 Discourse.prototype.getCreatedTopicsSync = function(username) {
 
   return this.getSync('topics/created-by/' + (username || this.api_username)+ '.json');
+
+};
+
+Discourse.prototype.getLastPostIdSync = function() {
+
+    var body = JSON.parse(this.getSync('/posts.json').body);
+    return body.latest_posts[0].id;
 
 };
 


### PR DESCRIPTION
Useful to [iterate through all posts if you want to perform operations like search&replace](https://meta.discourse.org/t/batch-processing-to-search-and-replace-in-all-posts/33621).