### PR TITLE
Better error handling and param passing in getSync

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -505,16 +505,19 @@ Discourse.prototype.getCategories = function(parameters, callback) {
 
 /////////////////////
 // Synchronous HELPER
-////////////////////
+/////////////////////
 
-Discourse.prototype.getSync = function(url, parameters) {
+Discourse.prototype.getSync = function(url, parameters, auth) {
 
-  var getUrl = this.url + '/' + url +
-    '?api_key=' + this.api_key +
-    '&api_username=' + this.api_username +
-    '&' + querystring.stringify(parameters);
+  var qs = auth? {
+      api_key: this.api_key,
+      api_username: this.api_username
+  } : {};
+  for (var p in parameters) qs[p] = parameters[p];
 
-  return requestSync('GET', getUrl);
+  var getUrl = this.url + '/' + url;
+
+  return requestSync('GET', getUrl, {qs: qs});
 
 };
 
@@ -570,20 +573,25 @@ Discourse.prototype.createTopicSync = function(title, raw, category) {
 
 Discourse.prototype.getCreatedTopicsSync = function(username) {
 
-  return this.getSync('topics/created-by/' + (username || this.api_username)+ '.json');
+  return this.getSync('topics/created-by/' + (username || this.api_username)+ '.json', {}, true);
 
 };
 
 Discourse.prototype.getPostSync = function(post_id) {
 
-  return JSON.parse(this.getSync('posts/' + post_id + '.json').body);
+  return JSON.parse(this.getSync('posts/' + post_id + '.json', {}, true).body);
 
 };
 
 Discourse.prototype.getLastPostIdSync = function() {
 
-    var body = JSON.parse(this.getSync('/posts.json').body);
+  var response = this.getSync('posts.json');
+  if (response.statusCode === 200) {
+    var body = JSON.parse(response.body);
     return body.latest_posts[0].id;
+  } else {
+    throw new Error(response.headers.status);
+  }
 
 };
 


### PR DESCRIPTION
* Added error handling on `500 Internal Server error` when the response body is empty and JSON.parse would fail
* Let sync-request encode parameters. This should be done for async requests as well.
* Made authentication configurable in order to work around this [Discourse bug](https://meta.discourse.org/t/nomethoderror-undefined-method-title-for-nil-nilclass/34534)