### PR TITLE
Adding auth params to getLastPostIdSync

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -604,7 +604,7 @@ Discourse.prototype.getPostSync = function(post_id) {
 
 Discourse.prototype.getLastPostIdSync = function() {
 
-  var response = this.getSync('posts.json');
+  var response = this.getSync('posts.json', {}, true);
   if (response.statusCode === 200) {
     var body = JSON.parse(response.body);
     return body.latest_posts[0].id;


### PR DESCRIPTION
getLastPostIdSync redirects to login screen for discourse instances that are private.

Send API keys with the request.