### PR TITLE
Proper DELETE for sync-request

### DIFF
--- a/lib/discourse.js
+++ b/lib/discourse.js
@@ -164,17 +164,21 @@ Discourse.prototype.delete = function(url, parameters, callback) {
 
 };
 
-Discourse.prototype.deleteSync = function(url, parameters, callback) {
+Discourse.prototype.deleteSync = function (url, parameters, callback) {
 
-  var deleteUrl = this.url + '/' + url + '?api_key=' + this.api_key + '&api_username=' + this.api_username;
+  var deleteUrl = this.url + '/' + url;
+  var qs = {
+    api_key: this.api_key,
+    api_username: this.api_username
+  };
+  for (var p in parameters) qs[p] = parameters[p];
 
   return requestSync('DELETE', deleteUrl, {
     headers: {
       'content-type': 'application/json'
     },
-    body: JSON.stringify(parameters)
+    qs: qs
   });
-
 };
 
 //////////////////////////////


### PR DESCRIPTION
Don't mix&match query string with body parameters; put all parameters in the query.

Fixes ["Socket hangup"](https://github.com/ForbesLindesay/sync-request/issues/43#issuecomment-186575104) caused by sync-request.

BTW, might want to update the sync-request dep to 3.0 if test pass.