### PR TITLE
Fix for 5 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "querystring": "~0.2.0",
-    "request": "~2.30.0",
+    "request": "~2.74.0",
     "sync-request": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
discourse-api currently has a 5 vulnerable dependency paths, introducing 5 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/dhyasama/discourse-api) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team