### PR TITLE
Fix 404 error with getUserEmail

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -160,7 +160,7 @@ exports = module.exports = function(Discourse, actionTypeEnum) {
   };
 
   Discourse.prototype.getUserEmail = function (username, callback) {
-    this.put('users/' + username + '/emails.json',
+    this.get('users/' + username + '/emails.json',
       {context: '/users/' + username + '/activity'},
       function (error, body, httpCode) {
         callback(error, body, httpCode);


### PR DESCRIPTION
`this.put` would not work with Discourse 1.8